### PR TITLE
[WIP] Use `mmap` in `from_par_iter`

### DIFF
--- a/merkle/Cargo.toml
+++ b/merkle/Cargo.toml
@@ -16,6 +16,7 @@ categories    = ["data-structures", "cryptography"]
 
 [dependencies]
 rayon = "1.0.0"
+memmap = "0.6"
 ring = { version = "^0.12.1", optional = true }
 rust-crypto = { version = "^0.2.36", optional = true }
 rand = { version = "^0.3", optional = true }

--- a/merkle/src/lib.rs
+++ b/merkle/src/lib.rs
@@ -160,6 +160,8 @@
 
 extern crate rayon;
 
+extern crate memmap;
+
 /// Hash infrastructure for items in Merkle tree.
 pub mod hash;
 

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -1,4 +1,6 @@
 use hash::{Algorithm, Hashable};
+use memmap::MmapMut;
+use memmap::MmapOptions;
 use proof::Proof;
 use rayon::prelude::*;
 use std::iter::FromIterator;
@@ -172,6 +174,10 @@ impl<T: Ord + Clone + AsRef<[u8]> + Sync + Send, A: Algorithm<T>> MerkleTree<T, 
     }
 }
 
+fn anonymous_mmap(len: usize) -> MmapMut {
+    unsafe { MmapOptions::new().len(len).map_anon().unwrap() }
+}
+
 impl<T: Ord + Clone + AsRef<[u8]> + Send + Sync, A: Algorithm<T>> FromParallelIterator<T>
     for MerkleTree<T, A>
 {
@@ -182,7 +188,7 @@ impl<T: Ord + Clone + AsRef<[u8]> + Send + Sync, A: Algorithm<T>> FromParallelIt
             Some(e) => {
                 let pow = next_pow2(e);
                 let size = 2 * pow - 1;
-                Vec::with_capacity(size)
+                (*anonymous_mmap(size)).to_vec()
             }
             None => Vec::new(),
         };


### PR DESCRIPTION
This currently doesn't work because `MerkleTree` can be any `T` but `MmapMut` only supports `u8`,

```
191 |                 (*anonymous_mmap(size)).to_vec()
    |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected type parameter, found u8
    |
    = note: expected type `std::vec::Vec<T>`
               found type `std::vec::Vec<u8>`
```