### PR TITLE
cargo.toml: update ring dependency

### DIFF
--- a/merkle/Cargo.toml
+++ b/merkle/Cargo.toml
@@ -16,7 +16,7 @@ categories    = ["data-structures", "cryptography"]
 
 [dependencies]
 rayon = "1.0.0"
-ring = { version = "^0.12.1", optional = true }
+ring = { version = "^0.14.1", optional = true }
 rust-crypto = { version = "^0.2.36", optional = true }
 rand = { version = "^0.3", optional = true }
 


### PR DESCRIPTION
Fixes:

```
    Updating crates.io index
error: failed to select a version for the requirement `ring = "^0.12.1"`
  candidate versions found which didn't match: 0.14.6, 0.14.5, 0.14.4, ...
  location searched: crates.io index
```