### PR TITLE
[WIP] Use `mmap` in `from_par_iter` (with `transmute`)

### DIFF
--- a/merkle/Cargo.toml
+++ b/merkle/Cargo.toml
@@ -17,6 +17,7 @@ categories    = ["data-structures", "cryptography"]
 [dependencies]
 rayon = "1.0.0"
 ring = { version = "^0.14.1", optional = true }
+memmap = "0.6"
 rust-crypto = { version = "^0.2.36", optional = true }
 rand = { version = "^0.3", optional = true }
 

--- a/merkle/src/lib.rs
+++ b/merkle/src/lib.rs
@@ -152,13 +152,14 @@
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
     unstable_features,
     unused_import_braces
 )]
 #![cfg_attr(feature = "nightly", allow(unstable_features))]
 
 extern crate rayon;
+
+extern crate memmap;
 
 /// Hash infrastructure for items in Merkle tree.
 pub mod hash;

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -1,9 +1,13 @@
 use hash::{Algorithm, Hashable};
+use memmap::MmapMut;
+use memmap::MmapOptions;
 use proof::Proof;
 use rayon::prelude::*;
 use std::iter::FromIterator;
 use std::marker::PhantomData;
+use std::mem;
 use std::ops;
+use std::slice;
 
 /// Merkle Tree.
 ///
@@ -172,6 +176,10 @@ impl<T: Ord + Clone + AsRef<[u8]> + Sync + Send, A: Algorithm<T>> MerkleTree<T, 
     }
 }
 
+fn anonymous_mmap(len: usize) -> MmapMut {
+    MmapOptions::new().len(len).map_anon().unwrap()
+}
+
 impl<T: Ord + Clone + AsRef<[u8]> + Send + Sync, A: Algorithm<T>> FromParallelIterator<T>
     for MerkleTree<T, A>
 {
@@ -182,7 +190,12 @@ impl<T: Ord + Clone + AsRef<[u8]> + Send + Sync, A: Algorithm<T>> FromParallelIt
             Some(e) => {
                 let pow = next_pow2(e);
                 let size = 2 * pow - 1;
-                Vec::with_capacity(size)
+                let mmap_slice = &(*anonymous_mmap(size * 2 * mem::size_of::<T>()));
+                unsafe {
+                    let parameter_slice = mem::transmute::<&[u8], &[T]>(mmap_slice);
+                    let adjusted_slice = slice::from_raw_parts(parameter_slice.as_ptr(), size);
+                    adjusted_slice.to_vec()
+                }
             }
             None => Vec::new(),
         };


### PR DESCRIPTION
Based on https://github.com/filecoin-project/merkle_light/pull/7.

This still is not using `mmap`, just replacing `Vec<T>` with `Box<T>` ~(which works in `zigzag`)~.

(edit: worked on a small local `zigzag` example but actually fails the test in https://github.com/filecoin-project/rust-fil-proofs/pull/518 which tries to use this PR)