### PR TITLE
`mmap`: file-mapping `Store`

### DIFF
--- a/merkle/Cargo.toml
+++ b/merkle/Cargo.toml
@@ -25,6 +25,7 @@ ring = { version = "^0.14.1", optional = true }
 rust-crypto = { version = "^0.2.36", optional = true }
 rand = { version = "^0.3", optional = true }
 arrayref = "0.3.5"
+tempfile = "3.0.7"
 
 [dev-dependencies]
 byteorder = "1.3.1"

--- a/merkle/src/lib.rs
+++ b/merkle/src/lib.rs
@@ -152,7 +152,7 @@
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
-    unsafe_code,
+// FIXME: Removing `unsafe_code`, used in DiskMmapStore::new(), is this correct?
     unstable_features,
     unused_import_braces
 )]
@@ -161,6 +161,8 @@
 extern crate rayon;
 
 extern crate memmap;
+
+extern crate tempfile;
 
 /// Hash infrastructure for items in Merkle tree.
 pub mod hash;

--- a/merkle/src/lib.rs
+++ b/merkle/src/lib.rs
@@ -152,7 +152,7 @@
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
-// FIXME: Removing `unsafe_code`, used in DiskMmapStore::new(), is this correct?
+    unsafe_code,
     unstable_features,
     unused_import_braces
 )]

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -407,18 +407,6 @@ impl<E: Element> Store<E> for DiskMmapStore<E> {
 
 impl<E: Element> DiskMmapStore<E> {
     pub fn new_with_path(size: usize, path: &Path) -> Self {
-        // FIXME: CROSSING API BOUNDARIES HERE.
-        // This is used by `rust-fil-proofs` code when it allocates a `Store`
-        // to use it with `MerkleTree::from_data_with_store`, but the `Store`
-        // created there has an assigned size of *only* the leaves (the data,
-        // as it's seen there), not the *entire* tree, which is expected since
-        // the consumer shouldn't need to know how big the final `Store` is
-        // going to be. To *temporarily* accommodate this we *mangle* the
-        // received `size` (in a similar way to `MerkleTree::from_iter`) to
-        // expand it to the entire tree.
-        let pow = next_pow2(size);
-        let size = 2 * pow - 1;
-
         let byte_len = E::byte_len() * size;
         let file: File = OpenOptions::new()
             .read(true)

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -468,12 +468,25 @@ impl<E: Element> DiskMmapStore<E> {
             }
         }
         if need_to_reload_store {
-            let mmap = self.store.write().unwrap();
+            let mut mmap = self.store.write().unwrap();
 
-            //        let new_store: DiskMmapStore<E> = DiskMmapStore::new_with_path(self.size.expect("couldn't find size"), Path::new(&self.path));
-            //        self.store = Arc::new(RwLock::new(*new_store.store()));
-            //        // FIXME: Extract part of the `MmapMut` creation logic to avoid
-            //        //  recreating the entire `DiskMmapStore`.
+            let new_store: DiskMmapStore<E> = DiskMmapStore::new_with_path(self.size.expect("couldn't find size"), Path::new(&self.path));
+//            self.store = Arc::new(RwLock::new();
+            // FIXME: Extract part of the `MmapMut` creation logic to avoid
+            //  recreating the entire `DiskMmapStore`.
+
+            // FIXME: How to store the new mmap structure? Both options are
+            //  failing.
+
+            // Option 1:
+            let new_mmap_lock = new_store.store.read().unwrap();
+            *mmap = Some(new_mmap_lock.unwrap());
+
+            // Option 2:
+            match *new_store.store.read().unwrap() {
+                Some(ref new_mmap) => {*mmap = Some(*new_mmap)},
+                None => panic!("The store has not been reloaded"),
+            }
         }
     }
 }

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -483,26 +483,7 @@ impl<E: Element> DiskMmapStore<E> {
 //  just recreate the same object (as the original will be dropped).
 impl<E: Element> Clone for DiskMmapStore<E> {
     fn clone(&self) -> DiskMmapStore<E> {
-        if self.path.is_empty() {
-            panic!("We don't allow cloning non-temporary files at the moment");
-        }
-
-        // FIXME: How to implement the clone? (the clone itself shouldn't
-        //  actually be used).
-        match *self.store.read().unwrap() {
-            Some(ref mmap) => {
-                return DiskMmapStore {
-                    store: Arc::new(RwLock::new(Some(*self.store.read().unwrap()))),
-                    len: self.len(),
-                    _e: Default::default(),
-                    file: self.file,
-                    store_size: self.store_size,
-                    path: self.path,
-                    size: self.size,
-                };
-            }
-            None => panic!("Trying to copy an unloaded store"),
-        }
+        unimplemented!("We can't clone a mmap with an already associated file");
     }
 }
 
@@ -531,7 +512,7 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
     //  `from_par_iter`) should be extended to handled a pre-allocated `Store`.
     pub fn from_data_with_store<I: IntoIterator<Item = T>>(
         into: I,
-        data: &mut K,
+        mut data: K,
     ) -> MerkleTree<T, A, K> {
         let iter = into.into_iter();
 
@@ -540,11 +521,6 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
 
         let pow = next_pow2(leafs);
         let size = 2 * pow - 1;
-
-        let mut data = data.clone();
-        // FIXME: We shouldn't clone here (which would reallocate), instead use
-        //  a mutable reference, that will make necessary to change also the
-        //  `MerkleTree::data` to a reference.
 
         // leafs
         let mut a = A::default();

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -434,13 +434,13 @@ impl<E: Element> DiskMmapStore<E> {
         return self.store_size;
     }
 
-    pub fn store_read_range<'a>(&'a self, start: usize, end: usize) -> &'a [u8] {
+    pub fn store_read_range(&self, start: usize, end: usize) -> Vec<u8> {
         self.reload_store();
         // FIXME: Not actually thread safe, the `store` could have been offloaded
         //  after this call (but we're not striving for thread-safety at the moment).
 
         match *self.store.read().unwrap() {
-            Some(ref mmap) => return &mmap[start..end],
+            Some(ref mmap) => return mmap[start..end].to_vec(),
             None => panic!("The store has not been reloaded"),
         }
     }

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -408,7 +408,7 @@ impl<E: Element> DiskMmapStore<E> {
             .write(true)
             .create(true)
             .open(&path)
-            .unwrap();
+            .expect("cannot create file");
         file.set_len(byte_len as u64).unwrap();
 
         let mmap = unsafe { MmapMut::map_mut(&file).expect("couldn't create map_mut") };

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -93,7 +93,7 @@ pub trait Store<E: Element>: ops::Deref<Target = [E]> + std::fmt::Debug + Clone 
     // (its mechanism should be transparent to the user who doesn't need to
     // manually reload).
     // Returns `true` if it was able to comply.
-    fn offload(&mut self) -> bool;
+    fn offload(&self) -> bool;
 }
 
 #[derive(Debug, Clone)]
@@ -151,7 +151,7 @@ impl<E: Element> Store<E> for VecStore<E> {
         self.0.push(el);
     }
 
-    fn offload(&mut self) -> bool {
+    fn offload(&self) -> bool {
         return false;
     }
 }
@@ -244,7 +244,7 @@ impl<E: Element> Store<E> for MmapStore<E> {
         self.write_at(el, l);
     }
 
-    fn offload(&mut self) -> bool {
+    fn offload(&self) -> bool {
         return false;
     }
 }
@@ -391,7 +391,7 @@ impl<E: Element> Store<E> for DiskMmapStore<E> {
 
     // Offload the `store` in the case it was constructed with `new_with_path`.
     // Temporary files with no path (created from `new`) can't be offloaded.
-    fn offload(&mut self) -> bool {
+    fn offload(&self) -> bool {
         if self.path.is_empty() {
             // Temporary file.
             return false;
@@ -572,7 +572,7 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
     }
 
     #[inline]
-    pub fn offload_store(&mut self) -> bool {
+    pub fn offload_store(&self) -> bool {
         return self.data.offload();
     }
 

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -425,7 +425,7 @@ impl<E: Element> DiskMmapStore<E> {
     }
 
     pub fn store_size(&self) -> usize {
-        return self.store_size;
+        self.store_size
     }
 
     pub fn store_read_range(&self, start: usize, end: usize) -> Vec<u8> {
@@ -434,7 +434,7 @@ impl<E: Element> DiskMmapStore<E> {
         //  after this call (but we're not striving for thread-safety at the moment).
 
         match *self.store.read().unwrap() {
-            Some(ref mmap) => return mmap[start..end].to_vec(),
+            Some(ref mmap) => mmap[start..end].to_vec(),
             None => panic!("The store has not been reloaded"),
         }
     }
@@ -442,7 +442,7 @@ impl<E: Element> DiskMmapStore<E> {
     pub fn store_copy_from_slice(&self, start: usize, end: usize, slice: &[u8]) {
         self.reload_store();
         match *self.store.write().unwrap() {
-            Some(ref mut mmap) => return mmap[start..end].copy_from_slice(slice),
+            Some(ref mut mmap) => mmap[start..end].copy_from_slice(slice),
             None => panic!("The store has not been reloaded"),
         }
     }
@@ -540,7 +540,7 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
 
     #[inline]
     pub fn try_offload_store(&self) -> bool {
-        return self.data.try_offload();
+        self.data.try_offload()
     }
 
     #[inline]

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -424,7 +424,9 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
     /// `DiskMmapStore::new_with_path` to set its path before instantiating
     /// the MT, which would otherwise just call `DiskMmapStore::new`).
     // FIXME: Taken from `MerkleTree::from_iter` to avoid adding more complexity,
-    //  it should use the parallel version instead.
+    //  it should receive a `parallel` flag to decide what to do.
+    // FIXME: We're repeating too much code here, `from_iter` (and
+    //  `from_par_iter`) should be extended to handled a pre-allocated `Store`.
     pub fn from_data_with_store<I: IntoIterator<Item = T>>(
         into: I,
         data: K,

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -74,6 +74,8 @@ pub trait Element: Ord + Clone + AsRef<[u8]> + Sync + Send + Default + std::fmt:
 /// Backing store of the merkle tree.
 pub trait Store<E: Element>: ops::Deref<Target = [E]> + std::fmt::Debug + Clone {
     /// Creates a new store which can store up to `size` elements.
+    // FIXME: Return errors on failure instead of panicking
+    //  (see https://github.com/filecoin-project/merkle_light/issues/19).
     fn new(size: usize) -> Self;
 
     fn new_from_slice(size: usize, data: &[u8]) -> Self;
@@ -393,14 +395,14 @@ impl<E: Element> Store<E> for DiskMmapStore<E> {
 
         *self.store.write().unwrap() = None;
 
-        //        println!("\n[LOG] Offloaded mmap file: {}", self.path);
-
         true
     }
 }
 
 impl<E: Element> DiskMmapStore<E> {
     #[allow(unsafe_code)]
+    // FIXME: Return errors on failure instead of panicking
+    //  (see https://github.com/filecoin-project/merkle_light/issues/19).
     pub fn new_with_path(size: usize, path: &Path) -> Self {
         let byte_len = E::byte_len() * size;
         let file: File = OpenOptions::new()
@@ -468,8 +470,6 @@ impl<E: Element> DiskMmapStore<E> {
                 .unwrap();
 
             std::mem::replace(&mut *store, new_store);
-
-            // println!("\n[LOG] Reloaded mmap file: {}", self.path);
         }
     }
 }

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -302,7 +302,7 @@ impl<E: Element> Store<E> for DiskMmapStore<E> {
         let byte_len = E::byte_len() * size;
         let file: File = tempfile().expect("couldn't create temp file");
         file.set_len(byte_len as u64)
-            .expect(&format!("couldn't set len of {}", byte_len));
+            .unwrap_or_else(|_| panic!("couldn't set len of {}", byte_len));
 
         let mmap = unsafe { MmapMut::map_mut(&file).expect("couldn't create map_mut") };
         let mmap_size = mmap.len();
@@ -584,7 +584,7 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
 
             width >>= 1;
             i = j;
-            j = j + width;
+            j += width;
             height += 1;
         }
 

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -456,12 +456,8 @@ impl<E: Element> DiskMmapStore<E> {
     // Checks if the `store` is loaded and reloads it if necessary.
     // FIXME: Check how to compact this logic.
     fn reload_store(&self) {
-        let mut need_to_reload_store = false;
-        {
-            if self.store.read().unwrap().is_none() {
-                need_to_reload_store = true;
-            }
-        }
+        let need_to_reload_store = self.store.read().unwrap().is_none();
+
         if need_to_reload_store {
             let new_store: DiskMmapStore<E> = DiskMmapStore::new_with_path(
                 self.size.expect("couldn't find size"),


### PR DESCRIPTION
Used in https://github.com/filecoin-project/rust-fil-proofs/pull/567.