### PR TITLE
Define constant used as threshold to decide between small and big `build`s

### DIFF
--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -1,9 +1,8 @@
 #![cfg(test)]
 
 use hash::*;
-use merkle::log2_pow2;
-use merkle::next_pow2;
-use merkle::{DiskMmapStore, Element, MerkleTree, MmapStore, VecStore};
+use merkle::{log2_pow2, next_pow2};
+use merkle::{DiskMmapStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD};
 use std::fmt;
 use std::hash::Hasher;
 use std::iter::FromIterator;
@@ -360,7 +359,7 @@ fn test_simple_tree() {
 #[test]
 fn test_large_tree() {
     let mut a = XOR128::new();
-    let count = 1024 * 1024;
+    let count = SMALL_TREE_BUILD * 2;
     let mt0: MerkleTree<[u8; 16], XOR128, MmapStore<_>> =
         MerkleTree::from_iter((0..count).map(|x| {
             a.reset();

--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -360,12 +360,38 @@ fn test_simple_tree() {
 fn test_large_tree() {
     let mut a = XOR128::new();
     let count = SMALL_TREE_BUILD * 2;
-    let mt0: MerkleTree<[u8; 16], XOR128, MmapStore<_>> =
-        MerkleTree::from_iter((0..count).map(|x| {
-            a.reset();
-            x.hash(&mut a);
-            a.hash()
-        }));
 
-    assert_eq!(mt0.len(), 2 * count - 1);
+    // The large `build` algorithm uses a ad hoc parallel solution (instead
+    // of the standard `par_iter()` from Rayon) so test these many times
+    // to increase the chances of finding a data-parallelism bug. (We're
+    // using a size close to the `SMALL_TREE_BUILD` threshold so this
+    // shouldn't increase test times considerably.)
+    for i in 0..100 {
+        let mt_vec: MerkleTree<[u8; 16], XOR128, VecStore<_>> =
+            MerkleTree::from_iter((0..count).map(|x| {
+                a.reset();
+                x.hash(&mut a);
+                i.hash(&mut a);
+                a.hash()
+            }));
+        assert_eq!(mt_vec.len(), 2 * count - 1);
+
+        let mt_mmap: MerkleTree<[u8; 16], XOR128, MmapStore<_>> =
+            MerkleTree::from_iter((0..count).map(|x| {
+                a.reset();
+                x.hash(&mut a);
+                i.hash(&mut a);
+                a.hash()
+            }));
+        assert_eq!(mt_mmap.len(), 2 * count - 1);
+
+        let mt_disk_mmap: MerkleTree<[u8; 16], XOR128, DiskMmapStore<_>> =
+            MerkleTree::from_iter((0..count).map(|x| {
+                a.reset();
+                x.hash(&mut a);
+                i.hash(&mut a);
+                a.hash()
+            }));
+        assert_eq!(mt_disk_mmap.len(), 2 * count - 1);
+    }
 }


### PR DESCRIPTION
```
Extract small/large build threshold value as constant `SMALL_TREE_BUILD` and
document it. Use it as a parameter in `test_large_tree` to make sure both types
of `build`s are tested independent of the actual value of the threshold.
```

(Easier to review commit by commit as there's a `rustfmt` in the middle.)