### PR TITLE
Replace DiskMmapStore hybrid with disk-only DiskStore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ cache: cargo
 
 rust:
   - stable
-  - nightly-2019-02-26
+  - nightly-2019-08-09
 
 before_script:
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2019-02-26" ]]; then
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2019-08-09" ]]; then
      rustup component add clippy-preview;
     fi'
 
@@ -17,5 +17,5 @@ script:
   - cargo build --all-features
   - cargo test --all-features
   - cargo doc --all-features --no-deps
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2019-02-26" ]]; then cargo clippy --all -- -D warnings; fi'
-  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2019-02-26" ]]; then cargo build --benches --all-features --all --release; fi'
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2019-08-09" ]]; then cargo clippy --all -- -D warnings; fi'
+  - bash -c 'if [[ "$TRAVIS_RUST_VERSION" == "nightly-2019-08-09" ]]; then cargo build --benches --all-features --all --release; fi'

--- a/merkle/Cargo.toml
+++ b/merkle/Cargo.toml
@@ -26,6 +26,7 @@ rust-crypto = { version = "^0.2.36", optional = true }
 rand = { version = "^0.3", optional = true }
 arrayref = "0.3.5"
 tempfile = "3.0.7"
+positioned-io = "0.2"
 
 [dev-dependencies]
 byteorder = "1.3.1"

--- a/merkle/benches/crypto_sha512.rs
+++ b/merkle/benches/crypto_sha512.rs
@@ -14,7 +14,7 @@ use crypto::digest::Digest;
 use crypto::sha2::Sha512;
 use hash512::Hash512;
 use merkletree::hash::{Algorithm, Hashable};
-use merkletree::merkle::{DiskMmapStore, MerkleTree, VecStore};
+use merkletree::merkle::{DiskStore, MerkleTree, VecStore};
 use rand::Rng;
 use rayon::prelude::*;
 use std::hash::Hasher;
@@ -162,7 +162,7 @@ fn bench_crypto_sha512_from_data_160_vec(b: &mut Bencher) {
 #[bench]
 fn bench_crypto_sha512_from_data_160_mmap(b: &mut Bencher) {
     let values = tree_160();
-    b.iter(|| MerkleTree::<Hash512, A, DiskMmapStore<_>>::from_iter(values.clone()));
+    b.iter(|| MerkleTree::<Hash512, A, DiskStore<_>>::from_iter(values.clone()));
 }
 
 #[bench]
@@ -180,7 +180,7 @@ fn bench_crypto_sha512_from_data_30000_vec(b: &mut Bencher) {
 #[bench]
 fn bench_crypto_sha512_from_data_30000_mmap(b: &mut Bencher) {
     let values = tree_30000();
-    b.iter(|| MerkleTree::<Hash512, A, DiskMmapStore<_>>::from_iter(values.clone()));
+    b.iter(|| MerkleTree::<Hash512, A, DiskStore<_>>::from_iter(values.clone()));
 }
 
 #[bench]

--- a/merkle/src/lib.rs
+++ b/merkle/src/lib.rs
@@ -164,6 +164,8 @@ extern crate memmap;
 
 extern crate tempfile;
 
+extern crate positioned_io;
+
 /// Hash infrastructure for items in Merkle tree.
 pub mod hash;
 

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -715,7 +715,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
     }
 
     fn sync(&self) {
-        self.file.sync_all().expect("failed to sync file");
+        // self.file.sync_data().expect("failed to sync file");
         // FIXME: Should we use `flush` instead?
     }
 }

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -905,7 +905,7 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
             // pair of nodes to write them to the next level in concurrent threads.
             // Process `chunk_size` nodes in each thread at a time to reduce contention, optimized
             // for big sector sizes (small ones will just have one thread doing all the work).
-            let chunk_size = 1024;
+            let chunk_size = 65536;
             debug_assert_eq!(chunk_size % 2, 0);
             Vec::from_iter((read_start..read_start + width).step_by(chunk_size))
                 .par_iter()

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -21,12 +21,15 @@ use tempfile::tempfile;
 /// as less as possible with multiple threads competing to get the write lock.
 pub const SMALL_TREE_BUILD: usize = 1024;
 
+// Number of nodes to process in parallel during the `build` stage.
+pub const BUILD_CHUNK_NODES: usize = 1024;
+
 // Number of batched nodes processed and stored together in `populate_leaves` to
 // avoid single `push`es which degrades performance for `DiskStore`.
-pub const BUILD_LEAVES_BLOCK_SIZE: usize = 1024;
+pub const BUILD_LEAVES_BLOCK_SIZE: usize = 64 * BUILD_CHUNK_NODES;
 
-// Number of nodes to process in parallel during the `build` stage.
-pub const BUILD_CHUNK_NODES: usize = 64 * 1024;
+// FIXME: Hand-picked constants, some proper benchmarks should be done
+// to choose more appropriate values and document the decision.
 
 /// Merkle Tree.
 ///

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -1000,11 +1000,15 @@ fn populate_leaves<T: Element, A: Algorithm<T>, K: Store<T>, I: IntoIterator<Ite
             a.reset();
             buf.extend(a.leaf(item).as_ref());
             if buf.len() >= BUILD_LEAVES_BLOCK_SIZE * T::byte_len() {
-                leaves.copy_from_slice(&buf, leaves.len());
+                let leaves_len = leaves.len();
+                // FIXME: Integrate into `len()` call into `copy_from_slice`
+                // once we update to `stable` 1.36.
+                leaves.copy_from_slice(&buf, leaves_len);
                 buf.clear();
             }
         }
-        leaves.copy_from_slice(&buf, leaves.len());
+        let leaves_len = leaves.len();
+        leaves.copy_from_slice(&buf, leaves_len);
 
         leaves.sync();
 }

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -753,7 +753,7 @@ impl<E: Element> DiskStore<E> {
         assert_eq!(
             self.file
                 .read_at(start as u64, &mut read_data)
-                .expect(&format!(
+                .unwrap_or_else(|_| panic!(
                     "failed to read {} bytes from file at offset {}",
                     read_len, start
                 )),

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -626,7 +626,8 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
             Vec::from_iter((read_start..read_start + width).step_by(BUILD_CHUNK_NODES))
                 .par_iter()
                 .for_each(|&chunk_index| {
-                    let chunk_size = std::cmp::min(BUILD_CHUNK_NODES, read_start + width - chunk_index);
+                    let chunk_size =
+                        std::cmp::min(BUILD_CHUNK_NODES, read_start + width - chunk_index);
 
                     let chunk_nodes = {
                         // Read everything taking the lock once.
@@ -988,23 +989,26 @@ pub fn log2_pow2(n: usize) -> usize {
     n.trailing_zeros() as usize
 }
 
-fn populate_leaves<T: Element, A: Algorithm<T>, K: Store<T>, I: IntoIterator<Item = T>>(leaves: &mut K, iter: <I as std::iter::IntoIterator>::IntoIter) {
-        let mut buf = Vec::with_capacity(BUILD_LEAVES_BLOCK_SIZE * T::byte_len());
+fn populate_leaves<T: Element, A: Algorithm<T>, K: Store<T>, I: IntoIterator<Item = T>>(
+    leaves: &mut K,
+    iter: <I as std::iter::IntoIterator>::IntoIter,
+) {
+    let mut buf = Vec::with_capacity(BUILD_LEAVES_BLOCK_SIZE * T::byte_len());
 
-        let mut a = A::default();
-        for item in iter {
-            a.reset();
-            buf.extend(a.leaf(item).as_ref());
-            if buf.len() >= BUILD_LEAVES_BLOCK_SIZE * T::byte_len() {
-                let leaves_len = leaves.len();
-                // FIXME: Integrate into `len()` call into `copy_from_slice`
-                // once we update to `stable` 1.36.
-                leaves.copy_from_slice(&buf, leaves_len);
-                buf.clear();
-            }
+    let mut a = A::default();
+    for item in iter {
+        a.reset();
+        buf.extend(a.leaf(item).as_ref());
+        if buf.len() >= BUILD_LEAVES_BLOCK_SIZE * T::byte_len() {
+            let leaves_len = leaves.len();
+            // FIXME: Integrate into `len()` call into `copy_from_slice`
+            // once we update to `stable` 1.36.
+            leaves.copy_from_slice(&buf, leaves_len);
+            buf.clear();
         }
-        let leaves_len = leaves.len();
-        leaves.copy_from_slice(&buf, leaves_len);
+    }
+    let leaves_len = leaves.len();
+    leaves.copy_from_slice(&buf, leaves_len);
 
-        leaves.sync();
+    leaves.sync();
 }

--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -487,8 +487,7 @@ impl<E: Element> DiskStore<E> {
             read_len
         );
 
-        read_data.clone()
-        // FIXME: Remove clone.
+        read_data
     }
 
     pub fn store_read_into(&self, start: usize, end: usize, buf: &mut [u8]) {

--- a/merkle/src/proof.rs
+++ b/merkle/src/proof.rs
@@ -56,7 +56,7 @@ impl<T: Eq + Clone + AsRef<[u8]>> Proof<T> {
     }
 
     /// Verifies MT inclusion proof and that leaf_data is the original leaf data for which proof was generated.
-    pub fn validate_with_data<A: Algorithm<T>>(&self, leaf_data: &Hashable<A>) -> bool {
+    pub fn validate_with_data<A: Algorithm<T>>(&self, leaf_data: &dyn Hashable<A>) -> bool {
         let mut a = A::default();
         leaf_data.hash(&mut a);
         let item = a.hash();

--- a/merkle/src/test_cmh.rs
+++ b/merkle/src/test_cmh.rs
@@ -20,7 +20,7 @@ impl CMH {
 impl Hasher for CMH {
     #[inline]
     fn write(&mut self, msg: &[u8]) {
-        <Hasher>::write(&mut self.0, msg)
+        <dyn Hasher>::write(&mut self.0, msg)
     }
 
     #[inline]

--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -3,7 +3,7 @@
 use hash::*;
 use merkle::{log2_pow2, next_pow2};
 use merkle::{
-    DiskMmapStore, DiskStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD,
+    DiskStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD,
 };
 use std::fmt;
 use std::hash::Hasher;
@@ -319,34 +319,31 @@ fn test_simple_tree() {
             let temp_dir = tempfile::tempdir().unwrap();
             // Hold on to the directory to avoid losing the created file-mmap inside.
 
-            let disk_mmap_leaves: DiskMmapStore<[u8; 16]> = DiskMmapStore::new_with_path(
+            let disk_leaves: DiskStore<[u8; 16]> = DiskStore::new_with_path(
                 next_pow2(leafs.len()),
                 &temp_dir
                     .path()
                     .to_owned()
-                    .join("test-xor-128-disk-mmap-leaves"),
+                    .join("test-xor-128-disk-leaves"),
             );
 
-            let disk_mmap_top_half: DiskMmapStore<[u8; 16]> = DiskMmapStore::new_with_path(
+            let disk_top_half: DiskStore<[u8; 16]> = DiskStore::new_with_path(
                 next_pow2(leafs.len()) - 1,
                 &temp_dir
                     .path()
                     .to_owned()
-                    .join("test-xor-128-disk-mmap-top-half"),
+                    .join("test-xor-128-disk-top-half"),
             );
 
-            let mt3: MerkleTree<_, XOR128, DiskMmapStore<_>> = MerkleTree::from_data_with_store(
+            let mt3: MerkleTree<_, XOR128, DiskStore<_>> = MerkleTree::from_data_with_store(
                 leafs.chunks_exact(16).map(|chunk| {
                     let mut array: [u8; 16] = Default::default();
                     array.copy_from_slice(chunk);
                     array
                 }),
-                disk_mmap_leaves,
-                disk_mmap_top_half,
+                disk_leaves,
+                disk_top_half,
             );
-
-            // Signal an offload before reloading when accessed later.
-            assert!(mt3.try_offload_store());
 
             assert_eq!(mt3.leafs(), items);
             assert_eq!(mt3.height(), log2_pow2(next_pow2(mt3.len())));
@@ -421,15 +418,6 @@ fn test_large_tree() {
                 a.hash()
             }));
         assert_eq!(mt_mmap.len(), 2 * count - 1);
-
-        let mt_disk_mmap: MerkleTree<[u8; 16], XOR128, DiskMmapStore<_>> =
-            MerkleTree::from_iter((0..count).map(|x| {
-                a.reset();
-                x.hash(&mut a);
-                i.hash(&mut a);
-                a.hash()
-            }));
-        assert_eq!(mt_disk_mmap.len(), 2 * count - 1);
 
         let mt_disk: MerkleTree<[u8; 16], XOR128, DiskStore<_>> =
             MerkleTree::from_iter((0..count).map(|x| {

--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -2,9 +2,7 @@
 
 use hash::*;
 use merkle::{log2_pow2, next_pow2};
-use merkle::{
-    DiskStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD,
-};
+use merkle::{DiskStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD};
 use std::fmt;
 use std::hash::Hasher;
 use std::iter::FromIterator;
@@ -321,10 +319,7 @@ fn test_simple_tree() {
 
             let disk_leaves: DiskStore<[u8; 16]> = DiskStore::new_with_path(
                 next_pow2(leafs.len()),
-                &temp_dir
-                    .path()
-                    .to_owned()
-                    .join("test-xor-128-disk-leaves"),
+                &temp_dir.path().to_owned().join("test-xor-128-disk-leaves"),
             );
 
             let disk_top_half: DiskStore<[u8; 16]> = DiskStore::new_with_path(

--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -2,7 +2,9 @@
 
 use hash::*;
 use merkle::{log2_pow2, next_pow2};
-use merkle::{DiskMmapStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD};
+use merkle::{
+    DiskMmapStore, DiskStore, Element, MerkleTree, MmapStore, VecStore, SMALL_TREE_BUILD,
+};
 use std::fmt;
 use std::hash::Hasher;
 use std::iter::FromIterator;
@@ -393,5 +395,14 @@ fn test_large_tree() {
                 a.hash()
             }));
         assert_eq!(mt_disk_mmap.len(), 2 * count - 1);
+
+        let mt_disk: MerkleTree<[u8; 16], XOR128, DiskStore<_>> =
+            MerkleTree::from_iter((0..count).map(|x| {
+                a.reset();
+                x.hash(&mut a);
+                i.hash(&mut a);
+                a.hash()
+            }));
+        assert_eq!(mt_disk.len(), 2 * count - 1);
     }
 }


### PR DESCRIPTION
This goes all the way towards minimizing memory use by working *only* over files (instead of using the file-mapped `mmap` intermediary) without an excessive increase in replication time (see https://github.com/filecoin-project/rust-fil-proofs/pull/796).

The reason to commit entirely to disk is that replication time is still dominated by node hashing and disk I/O (when the nodes are batched to avoid continuous read/writes) does not significantly change that fact.

Removing `DiskMmapStore` helps simplify the API both for MT and the `rust-fil-proofs` consumer: the offloading logic can be removed (both sides of the API needed to keep track of when we could dump `mmap` to disk) and avoids unnecessary options to the user to choose between disk-only and disk-`mmap` options.

This PR achieves the main objective of #26, although we should eventually incorporate the sub-tree traversal logic from it (which may provide an additional performance benefit).
