### PR TITLE
Minor improvements for loading DiskStores from disk.

### DIFF
--- a/merkle/src/merkle.rs
+++ b/merkle/src/merkle.rs
@@ -131,40 +131,17 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>> MerkleTree<T, A, K> {
     }
 
     /// Creates new merkle tree from an already allocated `Store`
-    /// (used with `DiskStore::new_from_disk`.
+    /// (used with `*Store::new_from_disk`).
     pub fn from_data_store(data: K, leafs: usize) -> MerkleTree<T, A, K> {
         let pow = next_pow2(leafs);
         let height = log2_pow2(2 * pow);
 
-        let elements = data.len() / T::byte_len();
-        let root = data.read_at(elements - 1);
+        let elements = data.len() / 2 + 1;
+        let root = data.read_at(data.len() - 1);
 
         MerkleTree {
             data,
-            leafs,
-            height,
-            root,
-            _a: PhantomData,
-            _t: PhantomData,
-        }
-    }
-
-    /// Creates new merkle from an already allocated and compacted
-    /// 'Store' (used with 'LevelCacheStore::new_from_disk').  For
-    /// now, the config isn't actually used, since it was already
-    /// required for the LevelCacheStore::new_from_disk call.
-    /// Depending, it may be needed here later though, so it's here
-    /// for now.
-    pub fn from_data_store_with_config(data: K, leafs: usize, _config: StoreConfig) -> MerkleTree<T, A, K> {
-        let pow = next_pow2(leafs);
-        let height = log2_pow2(2 * pow);
-
-        let elements = data.len();
-        let root = data.read_at(elements - 1);
-
-        MerkleTree {
-            data,
-            leafs,
+            leafs: elements,
             height,
             root,
             _a: PhantomData,

--- a/merkle/src/store.rs
+++ b/merkle/src/store.rs
@@ -11,6 +11,8 @@ use tempfile::tempfile;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+pub const DEFAULT_CACHED_ABOVE_BASE_LAYER: usize = 7;
+
 const STORE_CONFIG_DATA_VERSION: u32 = 1;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
@@ -22,6 +24,10 @@ pub struct StoreConfig {
     /// location for this particular data.
     pub id: String,
 
+    /// The number of elements in the DiskStore.  This field is
+    /// optional, and unused internally.
+    pub size: usize,
+
     /// The number of merkle tree levels above the base to cache on disk.
     pub levels: usize,
 }
@@ -31,6 +37,7 @@ impl StoreConfig {
         StoreConfig {
             path: PathBuf::from(path),
             id,
+            size: 0,
             levels
         }
     }
@@ -72,6 +79,7 @@ pub trait Store<E: Element>:
     fn read_range_into(&self, start: usize, end: usize, buf: &mut [u8]);
 
     fn len(&self) -> usize;
+    fn loaded_from_disk(&self) -> bool;
     fn is_empty(&self) -> bool;
     fn push(&mut self, el: E);
 
@@ -166,6 +174,10 @@ impl<E: Element> Store<E> for VecStore<E> {
         self.0.len()
     }
 
+    fn loaded_from_disk(&self) -> bool {
+        false
+    }
+
     fn compact(&mut self, _config: StoreConfig) -> Result<bool> {
         self.0.shrink_to_fit();
 
@@ -190,6 +202,11 @@ pub struct DiskStore<E: Element> {
     elem_len: usize,
     _e: PhantomData<E>,
     file: File,
+
+    // This flag is useful only immediate after instantiation, which
+    // is false if the store was newly initialized and true if the
+    // store was loaded from already existing on-disk data.
+    loaded_from_disk: bool,
 
     // We cache the `store.len()` call to avoid accessing disk unnecessarily.
     // Not to be confused with `len`, this saves the total size of the `store`
@@ -230,6 +247,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
             elem_len: E::byte_len(),
             _e: Default::default(),
             file: data,
+            loaded_from_disk: false,
             store_size: base_size,
         })
     }
@@ -245,6 +263,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
             elem_len: E::byte_len(),
             _e: Default::default(),
             file,
+            loaded_from_disk: false,
             store_size,
         })
     }
@@ -270,7 +289,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
     fn new_from_disk(size: usize, config: StoreConfig) -> Result<Self> {
         let data_path = StoreConfig::data_path(&config.path, &config.id);
 
-        let data = File::open(data_path)?;
+        let data = File::open(&data_path)?;
         let metadata = data.metadata()?;
         let store_size = metadata.len() as usize;
 
@@ -282,6 +301,7 @@ impl<E: Element> Store<E> for DiskStore<E> {
             elem_len: E::byte_len(),
             _e: Default::default(),
             file: data,
+            loaded_from_disk: true,
             store_size,
         })
     }
@@ -346,6 +366,10 @@ impl<E: Element> Store<E> for DiskStore<E> {
 
     fn len(&self) -> usize {
         self.len
+    }
+
+    fn loaded_from_disk(&self) -> bool {
+        self.loaded_from_disk
     }
 
     // Specifically, this method truncates an existing DiskStore and
@@ -462,7 +486,7 @@ impl<E: Element> DiskStore<E> {
     pub fn store_copy_from_slice(&mut self, start: usize, slice: &[u8]) {
         assert!(start + slice.len() <= self.store_size);
         self.file
-            .write_at(start as u64, slice)
+            .write_all_at(start as u64, slice)
             .expect("failed to write file");
     }
 }
@@ -648,6 +672,10 @@ impl<E: Element> Store<E> for LevelCacheStore<E> {
 
     fn len(&self) -> usize {
         self.len
+    }
+
+    fn loaded_from_disk(&self) -> bool {
+        true
     }
 
     fn compact(&mut self, _config: StoreConfig) -> Result<bool> {

--- a/merkle/src/store.rs
+++ b/merkle/src/store.rs
@@ -26,7 +26,7 @@ pub struct StoreConfig {
 
     /// The number of elements in the DiskStore.  This field is
     /// optional, and unused internally.
-    pub size: usize,
+    pub size: Option<usize>,
 
     /// The number of merkle tree levels above the base to cache on disk.
     pub levels: usize,
@@ -37,7 +37,7 @@ impl StoreConfig {
         StoreConfig {
             path: PathBuf::from(path),
             id,
-            size: 0,
+            size: None,
             levels
         }
     }

--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -387,6 +387,15 @@ fn test_various_trees_with_partial_cache() {
                     a.hash()
                 }), config.clone());
 
+            // Sanity check loading the store from disk and then
+            // re-creating the MT from it.
+            let store = DiskStore::new_from_disk(mt_cache.len(), config.clone()).unwrap();
+            let mt_cache2: MerkleTree<[u8; 16], XOR128, DiskStore<_>> =
+                MerkleTree::from_data_store(store, mt_cache.len());
+
+            assert_eq!(mt_cache.len(), mt_cache2.len());
+            assert_eq!(mt_cache.leafs(), mt_cache2.leafs());
+
             assert_eq!(mt_cache.len(), 2 * count - 1);
             assert_eq!(mt_cache.leafs(), count);
 
@@ -458,8 +467,7 @@ fn test_various_trees_with_partial_cache() {
             let level_cache_store: LevelCacheStore<[u8; 16]> =
                 Store::new_from_disk(count, config.clone()).unwrap();
             let mt_level_cache: MerkleTree<[u8; 16], XOR128, LevelCacheStore<_>> =
-                MerkleTree::from_data_store_with_config(
-                    level_cache_store, count, config);
+                MerkleTree::from_data_store(level_cache_store, count);
 
             // Sanity check that after rebuild, the new MT properties match the original.
             assert_eq!(mt_level_cache.len(), mt_cache_len);

--- a/merkle/src/test_xor128.rs
+++ b/merkle/src/test_xor128.rs
@@ -9,7 +9,8 @@ use rayon::iter::ParallelIterator;
 use std::iter::FromIterator;
 use std::fmt;
 use std::hash::Hasher;
-use store::{Store, DiskStore, VecStore, LevelCacheStore, StoreConfig};
+use store::{Store, DiskStore, VecStore, LevelCacheStore};
+use store::{StoreConfig, DEFAULT_CACHED_ABOVE_BASE_LAYER};
 
 const SIZE: usize = 0x10;
 
@@ -141,7 +142,8 @@ fn test_read_into() {
     let temp_dir = tempdir::TempDir::new("test_read_into").unwrap();
     let current_path = temp_dir.path().to_str().unwrap().to_string();
     let config = StoreConfig::new(
-        current_path, String::from("test-read-into"), 7);
+        current_path, String::from("test-read-into"),
+        DEFAULT_CACHED_ABOVE_BASE_LAYER);
 
     let mt2: MerkleTree<[u8; 16], XOR128, DiskStore<_>> =
         MerkleTree::from_data_with_config(&x, config);


### PR DESCRIPTION
Ensure that we don't rebuild tree data when loading from a previously
built store.