### PR TITLE
feat(iterators): short-circuit MT creation if iterator item is Err

### DIFF
--- a/src/test_cmh.rs
+++ b/src/test_cmh.rs
@@ -60,11 +60,12 @@ impl Algorithm<Item> for CMH {
 fn test_custom_merkle_hasher() {
     let mut a = CMH::new();
     let mt: MerkleTree<Item, CMH, VecStore<_>> =
-        MerkleTree::from_iter([1, 2, 3, 4, 5].iter().map(|x| {
+        MerkleTree::try_from_iter([1, 2, 3, 4, 5].iter().map(|x| {
             a.reset();
             x.hash(&mut a);
-            a.hash()
-        }));
+            Ok(a.hash())
+        }))
+        .unwrap();
 
     assert_eq!(
         mt.read_range(0, 3)

--- a/src/test_cmh.rs
+++ b/src/test_cmh.rs
@@ -6,7 +6,6 @@ use crate::store::VecStore;
 use crate::test_item::Item;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
-use std::iter::FromIterator;
 
 /// Custom merkle hash util test
 #[derive(Debug, Clone, Default)]

--- a/src/test_sip.rs
+++ b/src/test_sip.rs
@@ -98,16 +98,17 @@ fn test_simple_tree() {
     ];
     for items in 2..8 {
         let mut a = DefaultHasher::new();
-        let mt: MerkleTree<Item, DefaultHasher, VecStore<_>> = MerkleTree::from_iter(
+        let mt: MerkleTree<Item, DefaultHasher, VecStore<_>> = MerkleTree::try_from_iter(
             [1, 2, 3, 4, 5, 6, 7, 8]
                 .iter()
                 .map(|x| {
                     a.reset();
                     x.hash(&mut a);
-                    a.hash()
+                    Ok(a.hash())
                 })
                 .take(items),
-        );
+        )
+        .unwrap();
 
         assert_eq!(mt.leafs(), items);
         assert_eq!(mt.height(), log2_pow2(next_pow2(mt.len())));

--- a/src/test_sip.rs
+++ b/src/test_sip.rs
@@ -8,7 +8,6 @@ use crate::store::VecStore;
 use crate::test_item::Item;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::Hasher;
-use std::iter::FromIterator;
 
 impl Algorithm<Item> for DefaultHasher {
     #[inline]

--- a/src/test_xor128.rs
+++ b/src/test_xor128.rs
@@ -380,7 +380,7 @@ fn test_various_trees_with_partial_cache() {
                 i,
             );
             let mut mt_cache: MerkleTree<[u8; 16], XOR128, DiskStore<_>> =
-                MerkleTree::from_iter_with_config(
+                MerkleTree::try_from_iter_with_config(
                     (0..count).map(|x| {
                         a.reset();
                         x.hash(&mut a);


### PR DESCRIPTION
Blocks [this downstream rust-fil-proofs PR](https://github.com/filecoin-project/rust-fil-proofs/pull/978).

## Why does this PR exist?

Merkle tree creation (from an iterator) will panic under some circumstances. We don't want this.

## What's in this PR?

This PR removes the `FromIterator` `MerkleTree` instance (as its `from_iter` method returns `Self` instead of `Result<Self>` and replaces it with a `try_from_iter` that:

1. Accepts an iterator which can produce items that can fail
1. Returns a `Result` to allow for internal failures