### PR TITLE
WIP: compound tree enhancements

### DIFF
--- a/src/ccompound_merkle.rs
+++ b/src/ccompound_merkle.rs
@@ -62,9 +62,14 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned, R: Unsi
         // all properties revert to the single tree properties.  This
         // is done as an interface simplification where a
         // CCompoundMerkleTree can simply represent a CompoundMerkleTree.
-        let (leafs, len, height, root) = /*if top_layer_nodes == 1 {
-            (trees[0].leafs(), trees[0].len(), trees[0].height(), trees[0].root())
-        } else*/ {
+        let (leafs, len, height, root) = if top_layer_nodes == 1 {
+            (
+                trees[0].leafs(),
+                trees[0].len(),
+                trees[0].height(),
+                trees[0].root(),
+            )
+        } else {
             // Total number of leafs in the compound tree is the combined leafs total of all subtrees.
             let leafs = trees.iter().fold(0, |leafs, mt| leafs + mt.leafs());
             // Total length of the compound tree is the combined length of all subtrees plus the root.
@@ -114,6 +119,9 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned, R: Unsi
         // Generate the proof that will validate to the provided
         // sub-tree root (note the branching factor of N).
         let sub_tree_proof: CompoundMerkleProof<T, B, N> = tree.gen_proof(leaf_index)?;
+        if self.top_layer_nodes == 1 {
+            return CCompoundMerkleProof::<T, B, N, R>::new(sub_tree_proof, Vec::new(), Vec::new());
+        }
 
         // Construct the top layer proof.  'lemma' length is
         // top_layer_nodes - 1 + root == top_layer_nodes
@@ -158,6 +166,9 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned, R: Unsi
         // Generate the proof that will validate to the provided
         // sub-tree root (note the branching factor of N).
         let sub_tree_proof = tree.gen_proof_from_cached_tree(leaf_index, levels)?;
+        if self.top_layer_nodes == 1 {
+            return CCompoundMerkleProof::<T, B, N, R>::new(sub_tree_proof, Vec::new(), Vec::new());
+        }
 
         // Construct the top layer proof.  'lemma' length is
         // top_layer_nodes - 1 + root == top_layer_nodes

--- a/src/ccompound_merkle.rs
+++ b/src/ccompound_merkle.rs
@@ -1,0 +1,225 @@
+use std::marker::PhantomData;
+
+use anyhow::Result;
+
+use crate::ccompound_merkle_proof::CCompoundMerkleProof;
+use crate::compound_merkle::CompoundMerkleTree;
+use crate::compound_merkle_proof::CompoundMerkleProof;
+use crate::hash::Algorithm;
+use crate::merkle::Element;
+use crate::store::Store;
+use typenum::marker_traits::Unsigned;
+
+/// Compound Compound Merkle Tree.
+///
+/// A compound compound merkle tree is a type of compound merkle tree
+/// in which every non-leaf node is the hash of its child nodes.
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
+pub struct CCompoundMerkleTree<T, A, K, B, N, R>
+where
+    T: Element,
+    A: Algorithm<T>,
+    K: Store<T>,
+    B: Unsigned, // Branching factor of sub-trees
+    N: Unsigned, // Number of nodes at sub-tree top layer
+    R: Unsigned, // Number of nodes at top layer
+{
+    trees: Vec<CompoundMerkleTree<T, A, K, B, N>>,
+    top_layer_nodes: usize,
+    len: usize,
+    leafs: usize,
+    height: usize,
+    root: T,
+
+    _r: PhantomData<R>,
+}
+
+impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned, R: Unsigned>
+    CCompoundMerkleTree<T, A, K, B, N, R>
+{
+    /// Creates new compound merkle tree from a vector of merkle
+    /// trees.  The ordering of the trees is significant, as trees are
+    /// leaf indexed / addressable in the same sequence that they are
+    /// provided here.
+    pub fn from_trees(
+        trees: Vec<CompoundMerkleTree<T, A, K, B, N>>,
+    ) -> Result<CCompoundMerkleTree<T, A, K, B, N, R>> {
+        let top_layer_nodes = R::to_usize();
+        ensure!(
+            trees.len() == top_layer_nodes,
+            "Length of trees MUST equal the number of top layer nodes"
+        );
+        ensure!(
+            trees.iter().all(|ref mt| mt.height() == trees[0].height()),
+            "All passed in trees must have the same height"
+        );
+        ensure!(
+            trees.iter().all(|ref mt| mt.len() == trees[0].len()),
+            "All passed in trees must have the same length"
+        );
+
+        // If we are building a compound compound tree with only a single tree,
+        // all properties revert to the single tree properties.  This
+        // is done as an interface simplification where a
+        // CCompoundMerkleTree can simply represent a CompoundMerkleTree.
+        let (leafs, len, height, root) = /*if top_layer_nodes == 1 {
+            (trees[0].leafs(), trees[0].len(), trees[0].height(), trees[0].root())
+        } else*/ {
+            // Total number of leafs in the compound tree is the combined leafs total of all subtrees.
+            let leafs = trees.iter().fold(0, |leafs, mt| leafs + mt.leafs());
+            // Total length of the compound tree is the combined length of all subtrees plus the root.
+            let len = trees.iter().fold(0, |len, mt| len + mt.len()) + 1;
+            // Total height of the compound tree is the height of any of the sub-trees to top-layer plus root.
+            let height = trees[0].height() + 1;
+            // Calculate the compound root by hashing the top layer roots together.
+            let roots: Vec<T> = trees.iter().map(|x| x.root()).collect();
+            let root = A::default().multi_node(&roots, 1);
+
+            (leafs, len, height, root)
+        };
+
+        Ok(CCompoundMerkleTree {
+            trees,
+            top_layer_nodes,
+            len,
+            leafs,
+            height,
+            root,
+            _r: PhantomData,
+        })
+    }
+
+    /// Generate merkle tree inclusion proof for leaf `i`
+    pub fn gen_proof(&self, i: usize) -> Result<CCompoundMerkleProof<T, B, N, R>> {
+        ensure!(
+            i < self.leafs,
+            "{} is out of bounds (max: {})",
+            i,
+            self.leafs
+        ); // i in [0 .. self.leafs)
+
+        ensure!(
+            R::to_usize() == self.top_layer_nodes,
+            "Invalid top layer node value"
+        );
+
+        // Locate the sub-tree the leaf is contained in.
+        let tree_index = i / (self.leafs / self.top_layer_nodes);
+        let tree = &self.trees[tree_index];
+        let tree_leafs = tree.leafs();
+
+        // Get the leaf index within the sub-tree.
+        let leaf_index = i % tree_leafs;
+
+        // Generate the proof that will validate to the provided
+        // sub-tree root (note the branching factor of N).
+        let sub_tree_proof: CompoundMerkleProof<T, B, N> = tree.gen_proof(leaf_index)?;
+
+        // Construct the top layer proof.  'lemma' length is
+        // top_layer_nodes - 1 + root == top_layer_nodes
+        let mut path: Vec<usize> = Vec::with_capacity(1); // path - 1
+        let mut lemma: Vec<T> = Vec::with_capacity(self.top_layer_nodes);
+        for i in 0..self.top_layer_nodes {
+            if i != tree_index {
+                lemma.push(self.trees[i].root())
+            }
+        }
+
+        lemma.push(self.root());
+        path.push(tree_index);
+
+        // Generate the final compound tree proof which is composed of
+        // a sub-tree proof of branching factor B and a top-level
+        // proof with a branching factor of R.
+        CCompoundMerkleProof::<T, B, N, R>::new(sub_tree_proof, lemma, path)
+    }
+
+    /// Generate merkle tree inclusion proof for leaf `i` using partial trees built from cached data.
+    pub fn gen_proof_from_cached_tree(
+        &self,
+        i: usize,
+        levels: usize,
+    ) -> Result<CCompoundMerkleProof<T, B, N, R>> {
+        ensure!(
+            i < self.leafs,
+            "{} is out of bounds (max: {})",
+            i,
+            self.leafs
+        ); // i in [0 .. self.leafs)
+
+        // Locate the sub-tree the leaf is contained in.
+        let tree_index = i / (self.leafs / self.top_layer_nodes);
+        let tree = &self.trees[tree_index];
+        let tree_leafs = tree.leafs();
+
+        // Get the leaf index within the sub-tree.
+        let leaf_index = i % tree_leafs;
+
+        // Generate the proof that will validate to the provided
+        // sub-tree root (note the branching factor of N).
+        let sub_tree_proof = tree.gen_proof_from_cached_tree(leaf_index, levels)?;
+
+        // Construct the top layer proof.  'lemma' length is
+        // top_layer_nodes - 1 + root == top_layer_nodes
+        let mut path: Vec<usize> = Vec::with_capacity(1); // path - 1
+        let mut lemma: Vec<T> = Vec::with_capacity(self.top_layer_nodes);
+        for i in 0..self.top_layer_nodes {
+            if i != tree_index {
+                lemma.push(self.trees[i].root())
+            }
+        }
+
+        lemma.push(self.root());
+        path.push(tree_index);
+
+        // Generate the final compound tree proof which is composed of
+        // a sub-tree proof of branching factor B and a top-level
+        // proof with a branching factor of N.
+        CCompoundMerkleProof::<T, B, N, R>::new(sub_tree_proof, lemma, path)
+    }
+
+    pub fn top_layer_nodes(&self) -> usize {
+        self.top_layer_nodes
+    }
+
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    pub fn leafs(&self) -> usize {
+        self.leafs
+    }
+
+    pub fn height(&self) -> usize {
+        self.height
+    }
+
+    pub fn root(&self) -> T {
+        self.root.clone()
+    }
+
+    /// Returns merkle leaf element
+    #[inline]
+    pub fn read_at(&self, i: usize) -> Result<T> {
+        ensure!(
+            i < self.leafs,
+            "{} is out of bounds (max: {})",
+            i,
+            self.leafs
+        ); // i in [0 .. self.leafs)
+
+        // Locate the sub-tree the leaf is contained in.
+        let tree_index = i / (self.leafs / self.top_layer_nodes);
+        let tree = &self.trees[tree_index];
+        let tree_leafs = tree.leafs();
+
+        // Get the leaf index within the sub-tree.
+        let leaf_index = i % tree_leafs;
+
+        tree.read_at(leaf_index)
+    }
+}

--- a/src/ccompound_merkle_proof.rs
+++ b/src/ccompound_merkle_proof.rs
@@ -1,0 +1,225 @@
+use crate::hash::Algorithm;
+
+use anyhow::Result;
+use std::marker::PhantomData;
+use typenum::marker_traits::Unsigned;
+
+#[cfg(test)]
+use crate::ccompound_merkle::CCompoundMerkleTree;
+#[cfg(test)]
+use crate::compound_merkle::CompoundMerkleTree;
+use crate::compound_merkle_proof::CompoundMerkleProof;
+#[cfg(test)]
+use crate::hash::Hashable;
+#[cfg(test)]
+use crate::store::VecStore;
+#[cfg(test)]
+use crate::test_common::{get_vec_tree_from_slice, Item, XOR128};
+#[cfg(test)]
+use typenum::{U3, U4, U5, U8};
+
+/// CCompound Merkle Proof.
+///
+/// A compound merkle proof is a type of compound merkle tree proof.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct CCompoundMerkleProof<T: Eq + Clone + AsRef<[u8]>, U: Unsigned, N: Unsigned, R: Unsigned>
+{
+    sub_tree_proof: CompoundMerkleProof<T, U, N>,
+    lemma: Vec<T>,    // top layer proof hashes
+    path: Vec<usize>, // top layer tree index
+    _r: PhantomData<R>,
+}
+
+impl<T: Eq + Clone + AsRef<[u8]>, U: Unsigned, N: Unsigned, R: Unsigned>
+    CCompoundMerkleProof<T, U, N, R>
+{
+    /// Creates new compound MT inclusion proof
+    pub fn new(
+        sub_tree_proof: CompoundMerkleProof<T, U, N>,
+        lemma: Vec<T>,
+        path: Vec<usize>,
+    ) -> Result<CCompoundMerkleProof<T, U, N, R>> {
+        ensure!(lemma.len() == R::to_usize(), "Invalid lemma length");
+        Ok(CCompoundMerkleProof {
+            sub_tree_proof,
+            lemma,
+            path,
+            _r: PhantomData,
+        })
+    }
+
+    /// Return tree root
+    pub fn sub_tree_root(&self) -> T {
+        self.sub_tree_proof.root()
+    }
+
+    /// Return tree root
+    pub fn root(&self) -> T {
+        self.lemma.last().unwrap().clone()
+    }
+
+    /// Verifies MT inclusion proof
+    pub fn validate<A: Algorithm<T>>(&self) -> bool {
+        // Ensure that the sub_tree validates to the root of that
+        // sub_tree.
+        if !self.sub_tree_proof.validate::<A>() {
+            return false;
+        }
+
+        // Check that size is root + top_layer_nodes - 1.
+        let top_layer_nodes = R::to_usize();
+        if self.lemma.len() != top_layer_nodes {
+            return false;
+        }
+
+        // Check that the remaining proof matches the tree root (note
+        // that Proof::validate cannot handle a proof this small, so
+        // this is a version specific for what we know we have in this
+        // case).
+        let mut a = A::default();
+        a.reset();
+        let h = {
+            let mut nodes: Vec<T> = Vec::with_capacity(top_layer_nodes);
+            let mut cur_index = 0;
+            for j in 0..top_layer_nodes {
+                if j == self.path[0] {
+                    nodes.push(self.sub_tree_root().clone());
+                } else {
+                    nodes.push(self.lemma[cur_index].clone());
+                    cur_index += 1;
+                }
+            }
+
+            if cur_index != top_layer_nodes - 1 {
+                return false;
+            }
+
+            a.multi_node(&nodes, 0)
+        };
+
+        h == self.root()
+    }
+
+    /// Returns the path of this proof.
+    pub fn path(&self) -> &Vec<usize> {
+        &self.path
+    }
+
+    /// Returns the lemma of this proof.
+    pub fn lemma(&self) -> &Vec<T> {
+        &self.lemma
+    }
+}
+
+#[cfg(test)]
+// Break one element inside the proof's top layer.
+fn modify_proof<U: Unsigned, N: Unsigned, R: Unsigned>(
+    proof: &mut CCompoundMerkleProof<Item, U, N, R>,
+) {
+    use rand::prelude::*;
+
+    let i = random::<usize>() % proof.lemma.len();
+    let j = random::<usize>();
+
+    let mut a = XOR128::new();
+    j.hash(&mut a);
+
+    // Break random element
+    proof.lemma[i].hash(&mut a);
+    proof.lemma[i] = a.hash();
+}
+
+#[test]
+fn test_ccompound_quad_broken_proofs() {
+    let leafs = 16384;
+
+    let mt1 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt2 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt3 = get_vec_tree_from_slice::<U4>(leafs);
+    let cmt1: CompoundMerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
+        CompoundMerkleTree::from_trees(vec![mt1, mt2, mt3])
+            .expect("failed to build compound merkle tree");
+
+    let mt4 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt5 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt6 = get_vec_tree_from_slice::<U4>(leafs);
+    let cmt2: CompoundMerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
+        CompoundMerkleTree::from_trees(vec![mt4, mt5, mt6])
+            .expect("failed to build compound merkle tree");
+
+    let mt7 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt8 = get_vec_tree_from_slice::<U4>(leafs);
+    let mt9 = get_vec_tree_from_slice::<U4>(leafs);
+    let cmt3: CompoundMerkleTree<Item, XOR128, VecStore<_>, U4, U3> =
+        CompoundMerkleTree::from_trees(vec![mt7, mt8, mt9])
+            .expect("failed to build compound merkle tree");
+
+    let tree: CCompoundMerkleTree<Item, XOR128, VecStore<_>, U4, U3, U3> =
+        CCompoundMerkleTree::from_trees(vec![cmt1, cmt2, cmt3])
+            .expect("Failed to build ccompound tree");
+
+    for i in 0..tree.leafs() {
+        let mut p: CCompoundMerkleProof<Item, U4, U3, U3> = tree.gen_proof(i).unwrap();
+        assert!(p.validate::<XOR128>());
+
+        modify_proof(&mut p);
+        assert!(!p.validate::<XOR128>());
+    }
+}
+
+#[test]
+fn test_ccompound_octree_broken_proofs() {
+    let leafs = 32768;
+
+    let mt1 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt2 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt3 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt4 = get_vec_tree_from_slice::<U8>(leafs);
+    let cmt1: CompoundMerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
+        CompoundMerkleTree::from_trees(vec![mt1, mt2, mt3, mt4])
+            .expect("Failed to build compound tree");
+
+    let mt5 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt6 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt7 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt8 = get_vec_tree_from_slice::<U8>(leafs);
+    let cmt2: CompoundMerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
+        CompoundMerkleTree::from_trees(vec![mt5, mt6, mt7, mt8])
+            .expect("Failed to build compound tree");
+
+    let mt9 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt10 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt11 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt12 = get_vec_tree_from_slice::<U8>(leafs);
+    let cmt3: CompoundMerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
+        CompoundMerkleTree::from_trees(vec![mt9, mt10, mt11, mt12])
+            .expect("Failed to build compound tree");
+
+    let mt13 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt14 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt15 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt16 = get_vec_tree_from_slice::<U8>(leafs);
+    let cmt4: CompoundMerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
+        CompoundMerkleTree::from_trees(vec![mt13, mt14, mt15, mt16])
+            .expect("Failed to build compound tree");
+
+    let mt17 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt18 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt19 = get_vec_tree_from_slice::<U8>(leafs);
+    let mt20 = get_vec_tree_from_slice::<U8>(leafs);
+    let cmt5: CompoundMerkleTree<Item, XOR128, VecStore<_>, U8, U4> =
+        CompoundMerkleTree::from_trees(vec![mt17, mt18, mt19, mt20])
+            .expect("Failed to build compound tree");
+
+    let tree: CCompoundMerkleTree<Item, XOR128, VecStore<_>, U8, U4, U5> =
+        CCompoundMerkleTree::from_trees(vec![cmt1, cmt2, cmt3, cmt4, cmt5])
+            .expect("Failed to build compound tree");
+
+    for i in 0..tree.leafs() {
+        let mut p: CCompoundMerkleProof<Item, U8, U4, U5> = tree.gen_proof(i).unwrap();
+        assert!(p.validate::<XOR128>());
+
+        modify_proof(&mut p);
+        assert!(!p.validate::<XOR128>());
+    }
+}

--- a/src/compound_merkle.rs
+++ b/src/compound_merkle.rs
@@ -85,9 +85,14 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned>
         // all properties revert to the single tree properties.  This
         // is done as an interface simplification where a
         // CompoundMerkleTree can simply represent a MerkleTree.
-        let (leafs, len, height, root) = /*if top_layer_nodes == 1 {
-            (trees[0].leafs(), trees[0].len(), trees[0].height(), trees[0].root())
-        } else */ {
+        let (leafs, len, height, root) = if top_layer_nodes == 1 {
+            (
+                trees[0].leafs(),
+                trees[0].len(),
+                trees[0].height(),
+                trees[0].root(),
+            )
+        } else {
             // Total number of leafs in the compound tree is the combined leafs total of all subtrees.
             let leafs = trees.iter().fold(0, |leafs, mt| leafs + mt.leafs());
             // Total length of the compound tree is the combined length of all subtrees plus the root.
@@ -246,6 +251,9 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned>
         // Generate the proof that will validate to the provided
         // sub-tree root (note the branching factor of B).
         let sub_tree_proof: Proof<T, B> = tree.gen_proof(leaf_index)?;
+        if self.top_layer_nodes == 1 {
+            return CompoundMerkleProof::new(sub_tree_proof, Vec::new(), Vec::new());
+        }
 
         // Construct the top layer proof.  'lemma' length is
         // top_layer_nodes - 1 + root == top_layer_nodes
@@ -290,6 +298,9 @@ impl<T: Element, A: Algorithm<T>, K: Store<T>, B: Unsigned, N: Unsigned>
         // Generate the proof that will validate to the provided
         // sub-tree root (note the branching factor of B).
         let (sub_tree_proof, _) = tree.gen_proof_and_partial_tree(leaf_index, levels)?;
+        if self.top_layer_nodes == 1 {
+            return CompoundMerkleProof::new(sub_tree_proof, Vec::new(), Vec::new());
+        }
 
         // Construct the top layer proof.  'lemma' length is
         // top_layer_nodes - 1 + root == top_layer_nodes

--- a/src/compound_merkle_proof.rs
+++ b/src/compound_merkle_proof.rs
@@ -53,7 +53,10 @@ impl<T: Eq + Clone + AsRef<[u8]>, U: Unsigned, N: Unsigned> CompoundMerkleProof<
         lemma: Vec<T>,
         path: Vec<usize>,
     ) -> Result<CompoundMerkleProof<T, U, N>> {
-        if N::to_usize() != 1 {
+        if N::to_usize() == 1 {
+            // In this case, there is no top level proof, so no lemmas.
+            ensure!(lemma.is_empty(), "Invalid lemma length");
+        } else {
             ensure!(lemma.len() == N::to_usize(), "Invalid lemma length");
         }
 
@@ -133,10 +136,16 @@ impl<T: Eq + Clone + AsRef<[u8]>, U: Unsigned, N: Unsigned> CompoundMerkleProof<
     pub fn lemma(&self) -> &Vec<T> {
         &self.lemma
     }
+
+    /// Returns the lemma of this proof.
+    pub fn lemma_mut(&mut self) -> &mut Vec<T> {
+        &mut self.lemma
+    }
 }
 
 #[cfg(test)]
 // Break one element inside the proof's top layer (if available).
+// Otherwise, break the sub-proof.
 fn modify_proof<U: Unsigned, N: Unsigned>(proof: &mut CompoundMerkleProof<Item, U, N>) {
     use rand::prelude::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,11 +177,17 @@ pub mod proof;
 /// Compound Merkle tree inclusion proof.
 pub mod compound_merkle_proof;
 
+/// Compound compound Merkle tree inclusion proof.
+pub mod ccompound_merkle_proof;
+
 /// Merkle tree abstractions, implementation and algorithms.
 pub mod merkle;
 
 /// Compound Merkle tree abstractions, implementation and algorithms.
 pub mod compound_merkle;
+
+/// Compound compound Merkle tree abstractions, implementation and algorithms.
+pub mod ccompound_merkle;
 
 /// Re-usable Testing primitives
 pub mod test_common;

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -941,7 +941,7 @@ pub fn is_merkle_tree_size_valid(leafs: usize, branches: usize) -> bool {
     let shift = log2_pow2(branches);
     while cur != 1 {
         cur >>= shift; // cur /= branches
-        if cur > leafs || cur == 0 {
+        if cur >= leafs || cur == 0 {
             return false;
         }
     }

--- a/src/merkle.rs
+++ b/src/merkle.rs
@@ -941,8 +941,7 @@ pub fn is_merkle_tree_size_valid(leafs: usize, branches: usize) -> bool {
     let shift = log2_pow2(branches);
     while cur != 1 {
         cur >>= shift; // cur /= branches
-        assert!(cur < leafs);
-        if cur == 0 {
+        if cur > leafs || cur == 0 {
             return false;
         }
     }

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -108,6 +108,14 @@ impl<T: Eq + Clone + AsRef<[u8]>, U: Unsigned> Proof<T, U> {
     pub fn lemma(&self) -> &Vec<T> {
         &self.lemma
     }
+
+    /// DO NOT USE: this is provided for compound_merkle_proof testing
+    /// only.
+    ///
+    /// Returns the lemma of this proof as mutable.
+    pub fn lemma_mut(&mut self) -> &mut Vec<T> {
+        &mut self.lemma
+    }
 }
 
 #[cfg(test)]

--- a/src/test_xor128.rs
+++ b/src/test_xor128.rs
@@ -515,7 +515,9 @@ fn test_compound_tree_from_store_configs<B: Unsigned, N: Unsigned>(sub_tree_leaf
 
 // B: Branching factor of sub-trees
 // N: Branching factor of top-layer
-fn test_compound_levelcache_tree_from_store_configs<B: Unsigned, N: Unsigned>(sub_tree_leafs: usize) {
+fn test_compound_levelcache_tree_from_store_configs<B: Unsigned, N: Unsigned>(
+    sub_tree_leafs: usize,
+) {
     let branches = B::to_usize();
     assert!(is_merkle_tree_size_valid(sub_tree_leafs, branches));
 
@@ -530,8 +532,14 @@ fn test_compound_levelcache_tree_from_store_configs<B: Unsigned, N: Unsigned>(su
     let height = get_merkle_tree_height(sub_tree_leafs, branches);
 
     for i in 0..sub_tree_count {
-        let lc_name = format!("{}-{}-{}-{}-lc-{}", test_name, sub_tree_leafs, len, height, i);
-        let replica = format!("{}-{}-{}-{}-replica-{}", test_name, sub_tree_leafs, len, height, i);
+        let lc_name = format!(
+            "{}-{}-{}-{}-lc-{}",
+            test_name, sub_tree_leafs, len, height, i
+        );
+        let replica = format!(
+            "{}-{}-{}-{}-replica-{}",
+            test_name, sub_tree_leafs, len, height, i
+        );
         let config = StoreConfig::new(temp_dir.path(), String::from(&replica), levels);
         build_disk_tree_from_iter::<B>(sub_tree_leafs, len, height, &config);
 


### PR DESCRIPTION
In addition to existing compound tree enhancements, this adds functionality for having aggregations of compound trees, or compound compound trees in concept (poorly named as type CCompoundMerkleTree).  This is work in progress as it would be ideal to not have a CCompoundMerkleTree and instead define a recursive CompoundMerkleTree type.  I spent time investigating that route yesterday and today and haven't progressed, so I'm issuing this PR for reviews/ideas/suggestions on how to better solve that problem.  I believe it solves the specific issue that we're looking at regarding tree compositions, but could also be improved since the naming is at best clunky.  I'll continue to think about how to address this weekend as well, as this isn't intended to be merge ready as-is.